### PR TITLE
(maint) Use new GRM functionality

### DIFF
--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -25,8 +25,10 @@ create:
   include-sha-section: true
   sha-section-heading: "SHA256 Hashes of the release artifacts"
   sha-section-line-format: "- `{1}\t{0}`"
+  include-contributors: true
 close:
   use-issue-comments: true
+  set-due-date: true
   issue-comment: |-
     :tada: This issue has been resolved in version {milestone} :tada:
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.28.4
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.30.1
 
 ///////////////////////////////////////////////////////////////////////////////
 // SCRIPT


### PR DESCRIPTION
## Description Of Changes

This commit adds the new set-due-date and include-contributors configurations of GRM to true to set the due date of a milestone when it is being closed, and also to include information about contributors to the release notes.

Also, an update to the version of Chocolatey.Cake.Recipe is done to include the latest version of GitReleaseManager.

## Motivation and Context

With the latest release of GRM, new functionality has been provided, so it makes sense to make use of it.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- ENGTASKS-4856