### PR TITLE
(build) Add more build configurations

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,21 +2,23 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.*
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.xmlReport
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.XmlReport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nuGetPublish
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.ScheduleTrigger
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
-
-version = "2021.2"
 
 project {
     buildType(Checksum)
+    buildType(ChecksumSchd)
+    buildType(ChecksumQA)
 }
 
 object Checksum : BuildType({
     id = AbsoluteId("Checksum")
-    name = "Build"
+    name = "Build (Unit Tests)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     artifactRules = """
     """.trimIndent()
@@ -25,6 +27,7 @@ object Checksum : BuildType({
         param("env.vcsroot.branch", "%vcsroot.branch%")
         param("env.Git_Branch", "%teamcity.build.vcs.branch.Checksum_ChecksumVcsRoot%")
         param("teamcity.git.fetchAllHeads", "true")
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
     }
 
     vcs {
@@ -53,13 +56,19 @@ object Checksum : BuildType({
 
         script {
             name = "Call Cake"
-            scriptContent = "call build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=all --shouldRunOpenCover=false"
+            scriptContent = """
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
+            """.trimIndent()
         }
     }
 
     triggers {
         vcs {
-            branchFilter = ""
+            branchFilter = """
+                +:*
+                -:master
+                -:support/*
+            """.trimIndent()
         }
     }
 
@@ -70,6 +79,124 @@ object Checksum : BuildType({
                     token = "%system.GitHubPAT%"
                 }
             }
+        }
+    }
+})
+
+object ChecksumSchd : BuildType({
+    id = AbsoluteId("ChecksumSchd")
+    name = "Build (Scheduled Integration Testing)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
+    artifactRules = """
+    """.trimIndent()
+
+    params {
+        param("env.vcsroot.branch", "%vcsroot.branch%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.Checksum_ChecksumVcsRoot%")
+        param("teamcity.git.fetchAllHeads", "true")
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+
+        branchFilter = """
+            +:*
+        """.trimIndent()
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    choco install windows-sdk-7.1 netfx-4.8-devpack visualstudio2022-workload-manageddesktopbuildtools --confirm --no-progress
+                    exit ${'$'}LastExitCode
+                """.trimIndent()
+            }
+        }
+
+        script {
+            name = "Call Cake"
+            scriptContent = """
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=all --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
+            """.trimIndent()
+        }
+    }
+
+    triggers {
+        schedule {
+            schedulingPolicy = daily {
+                hour = 2
+                minute = 0
+            }
+            branchFilter = """
+                +:<default>
+            """.trimIndent()
+            triggerBuild = always()
+            withPendingChangesOnly = false
+        }
+    }
+})
+
+object ChecksumQA : BuildType({
+    id = AbsoluteId("ChecksumQA")
+    name = "Build (SonarQube)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
+    artifactRules = """
+    """.trimIndent()
+
+    params {
+        param("env.vcsroot.branch", "%vcsroot.branch%")
+        param("env.Git_Branch", "%teamcity.build.vcs.branch.Checksum_ChecksumVcsRoot%")
+        param("env.SONARQUBE_ID", "checksum")
+        param("teamcity.git.fetchAllHeads", "true")
+        password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+
+        branchFilter = """
+            +:*
+        """.trimIndent()
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    choco install windows-sdk-7.1 netfx-4.8-devpack visualstudio2022-workload-manageddesktopbuildtools --confirm --no-progress
+                    exit ${'$'}LastExitCode
+                """.trimIndent()
+            }
+        }
+
+        script {
+            name = "Call Cake"
+            scriptContent = """
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunSonarQube=true --shouldRunDependencyCheck=true --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
+            """.trimIndent()
+        }
+    }
+
+    triggers {
+        schedule {
+            schedulingPolicy = weekly {
+                dayOfWeek = ScheduleTrigger.DAY.Saturday
+                hour = 2
+                minute = 45
+            }
+            branchFilter = """
+                +:<default>
+            """.trimIndent()
+            triggerBuild = always()
+            withPendingChangesOnly = false
         }
     }
 })


### PR DESCRIPTION
## Description Of Changes

This commit overhauls the existing build configuration to match what is currently done in the Chocolatey CLI build, this includes:
 -  ensuring the GITHUB_PAT is in play
 - that only unit tests are executed
 - that the Slack Notification template is being used
 - only certain branches trigger builds

In addition, a two new build configurations are introduced.  One to run scheuled integration tests, and another to run scheduled SonarQube analysis.

## Motivation and Context

These changes bring some consistency on "how" our builds are executed across different project.

## Testing

@Windos what is the best way to test this?

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Build related changed
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A